### PR TITLE
Remove global installation using Vue.use

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,20 +13,8 @@ const plugin = {
   install,
 };
 
-// To auto-install when vue is found
-/* global window global */
-let GlobalVue = null;
-if (typeof window !== 'undefined') {
-  GlobalVue = window.Vue;
-} else if (typeof global !== 'undefined') {
-  GlobalVue = global.Vue;
-}
-if (GlobalVue) {
-  GlobalVue.use(plugin);
-}
-
 // Inject install function into component - allows component
-// to be registered via Vue.use() as well as Vue.component()
+// to be registered with Vue.component()
 component.install = install;
 
 // Export component by default


### PR DESCRIPTION
It is no longer supported by Vue 3
See https://v3-migration.vuejs.org/breaking-changes/global-api.html#a-note-for-plugin-authors for more information